### PR TITLE
Feature/FeatureCollection shouldn't require bbox

### DIFF
--- a/src/GeoJSON.js
+++ b/src/GeoJSON.js
@@ -143,14 +143,14 @@ type GeometryCollectionTemplate<G> = {
 
 type FeatureTemplate<G> = {
   type: 'Feature',
-  bbox: Bbox,
+  bbox: Bbox | void,
   properties: Properties,
   geometry: G,
 };
 
 type FeatureCollectionTemplate<F> = {
   type: 'FeatureCollection',
-  bbox: Bbox,
+  bbox: Bbox | void,
   features: F,
 };
 


### PR DESCRIPTION
Thanks for putting this together!

Looks like Feature, and FeatureCollection are always requiring a bbox, and should be optional from the spec? 